### PR TITLE
Use pulseaudio to capture the audio track directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,17 @@
 This code generates MKV files out of AC recordings and ingests them onto Kaltura.
 
 ## General flow
-
-- Download the ZIP archive and concat the audio FLVs into one MP3 using FFmpeg
+- Download the ZIP archive and concat the audio FLVs into one MP3 using FFmpeg [this is done in order to determine the session's length so that we know how long to record using FFmpeg's x11grab]
 - Using Selenium and Mozilla's Geckodriver, launch Firefox with Xvfb and navigate to the recording's URL so that it plays using the Adobe SWF
-- Use FFmpeg's x11grab option to capture the screen display
-- Once done, use FFmpeg's scene detection feature to determine when the recording had actually started [this is needed because the AC app takes a long time to load and there's no other way to ascertain how long it actually took]
-- Merge the audio and video files and use the Kaltura API to ingest the resulting file
+- Created the needed audio sinks so that the audio track can be captured [see `capture_audio.sh`]
+- Use FFmpeg's x11grab option to capture the screen display and audio [via pulse]
 
 ## Pre-requisites
 
 - cURL CLI
 - unzip
 - xvfb
+- pulseaudio [provided by the `pulaseuadio` and `pulseaudio-utils` packages in Debian/Ubuntu]
 - pidof [provided by the `sysvinit-utils` package in Debian/Ubuntu and by `sysvinit-tools` in RHEL/CentOS/FC]
 - Firefox with the Flash plugin loaded [tested with 60.0.1 but other recent versions should work as well]
 - Ruby [2.3 and 2.5 were tested]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This code generates MKV files out of AC recordings and ingests them onto Kaltura
 ## General flow
 - Download the ZIP archive and concat the audio FLVs into one MP3 using FFmpeg [this is done in order to determine the session's length so that we know how long to record using FFmpeg's x11grab]
 - Using Selenium and Mozilla's Geckodriver, launch Firefox with Xvfb and navigate to the recording's URL so that it plays using the Adobe SWF
-- Created the needed audio sinks so that the audio track can be captured [see `capture_audio.sh`]
+- Create the needed pulseaudio sinks so that the audio track can be captured [see `capture_audio.sh`]
 - Use FFmpeg's x11grab option to capture the screen display and audio [via pulse]
 
 ## Pre-requisites

--- a/ac_new.rb
+++ b/ac_new.rb
@@ -82,7 +82,6 @@ class Vconn1 < Test::Unit::TestCase
     resolution = '1280x720'
     frame_rate = '30'
     audio_file = out_dir + meeting_id + '.mp3'
-    captured_audio_file = out_dir + 'steam_' + meeting_id + '.ogg'
     recording_file = out_dir + meeting_id + '.mkv'
 
     audio_track_exists = true

--- a/ac_new.rb
+++ b/ac_new.rb
@@ -40,7 +40,7 @@ class Vconn1 < Test::Unit::TestCase
     @base_url = ENV['AC_ENDPOINT']
     @driver = Selenium::WebDriver.for :firefox, desired_capabilities: @caps
     @driver.manage.window.maximize
-    # @driver.manage.window.full_screen
+    #@driver.manage.window.full_screen
 
     @accept_next_alert = true
     @driver.manage.timeouts.implicit_wait = 30
@@ -82,8 +82,8 @@ class Vconn1 < Test::Unit::TestCase
     resolution = '1280x720'
     frame_rate = '30'
     audio_file = out_dir + meeting_id + '.mp3'
+    captured_audio_file = out_dir + 'steam_' + meeting_id + '.ogg'
     recording_file = out_dir + meeting_id + '.mkv'
-    full_recording_file = out_dir + meeting_id + '.full.mkv'
 
     audio_track_exists = true
     basedir = File.dirname(__FILE__)
@@ -119,34 +119,19 @@ class Vconn1 < Test::Unit::TestCase
       @driver.find_element(:id, 'login-button').click
     end
     @driver.get(@base_url + '/' + meeting_id + '?launcher=false&fcsContent=true&pbMode=normal')
-
+		# this PID file is created by capture_audio.sh
+		steam_pid = out_dir + '/steam_' + meeting_id + '.pid' 
     # FFmpeg magic
     # record X11's display
-    if !ffmpeg_x11_grab(ffmpeg_bin, resolution, frame_rate, x_display, extra_duration.to_s, recording_file)
+    if !ffmpeg_x11_grab(ffmpeg_bin, meeting_id, resolution, frame_rate, x_display, extra_duration.to_s, recording_file, steam_pid)
       return false
     end
 
-    # use scene detector feature to determine when the recording had actually started
-    if !first_scene = ffmpeg_detect_scene_start_time(ffmpeg_bin, recording_file, 1)
-      return false
-    end
 
-    # trim original screen recording so that it starts from when AC actually started playing the recording
-    if !ffmpeg_trim_video(ffmpeg_bin, recording_file, first_scene, dur_sec.to_s, out_dir + meeting_id + '.final.mkv')
-      return false
-    end
-
-    # merge video and audio files
-    if audio_track_exists && !ffmpeg_merge_vid_and_aud_tracks(ffmpeg_bin, out_dir + meeting_id + '.final.mkv', audio_file, full_recording_file)
-      return false
-    elsif !audio_track_exists
-      FileUtils.cp(out_dir + meeting_id + '.final.mkv', full_recording_file)
-    end
-
-    if File.exist?(full_recording_file)
-      @logger.info('Final output saved to: ' + full_recording_file + ' :)')
+    if File.exist?(recording_file)
+      @logger.info('Final output saved to: ' + recording_file + ' :)')
     else
-      @logger.error("Something failed and I couldn't find a " + full_recording_file + ' to process :(')
+      @logger.error("Something failed and I couldn't find a " + recording_file + ' to process :(')
       return false
     end
 
@@ -163,17 +148,30 @@ class Vconn1 < Test::Unit::TestCase
     sco_id = ENV['SCO_ID']
 
     client = init_client(ENV['KALTURA_BASE_ENDPOINT'], ENV['KALTURA_PARTNER_ID'], ENV['KALTURA_PARTNER_SECRET'])
-    ingest_to_kaltura(client, entry_name, meeting_id, sco_id, full_recording_file)
+    ingest_to_kaltura(client, entry_name, meeting_id, sco_id, recording_file)
   end
 
-  def ffmpeg_x11_grab(ffmpeg_bin, resolution, frame_rate, x_display, duration, recording_file)
-    # we crop the browser's address bar here because of https://github.com/mozilla/geckodriver/issues/1281
-    # if it's ever fixed, we could drop that and start Firefox in full screen mode with:
-    # @driver.manage.window.full_screen
-    ffmpeg_x11grab_command = ffmpeg_bin + ' -s ' + resolution + ' -framerate ' + frame_rate.to_s + ' -f x11grab -i :' + x_display.to_s + ' -t ' + duration.to_s + ' -vf "crop=in_w:in_h-147" -y ' + recording_file.shellescape
+  def ffmpeg_x11_grab(ffmpeg_bin, meeting_id, resolution, frame_rate, x_display, duration, recording_file, steam_pid)
+		my_sink = nil
+		# wait for the capture_audio magic to end so that we'll have pulse audio sinks
+		while ! File.exist?(steam_pid)
+			sleep 5 
+		end
+		my_sink, stdeerr, status = Open3.capture3("pacmd list-sources | grep -PB 1 \"" + meeting_id + ".*monitor>\" |  head -n 1 | perl -pe 's/.* //g'")
+		my_sink = my_sink.delete!("\n")
+		my_sink = my_sink.to_i
+		if ! my_sink.is_a? Numeric
+			return false
+		end
+    
+		# override duration for faster testing/debugging 
+    # duration = 120
+    ffmpeg_x11grab_command = ffmpeg_bin + ' -s ' + resolution + ' -framerate ' + frame_rate.to_s + ' -f x11grab -i :' + x_display.to_s + ' -f pulse -i ' + my_sink.to_s + '  -c:v libx264  -acodec libmp3lame -crf 0 -preset ultrafast -t ' + duration.to_s + ' -vf "crop=in_w:in_h-147" -y ' + recording_file.shellescape
     @logger.info('X11grab command is: ' + ffmpeg_x11grab_command)
 
-    system ffmpeg_x11grab_command
+    system ffmpeg_x11grab_command 
+		# delete the PID capture_audio.sh creates since we're done with it
+		File.delete(steam_pid) if File.exist?(steam_pid)
     if $?.exitstatus != 0
       @logger.error('ffmpeg x11grab command exited with ' + $?.exitstatus.to_s + ':(')
       return false
@@ -183,6 +181,7 @@ class Vconn1 < Test::Unit::TestCase
 
   def ffmpeg_detect_scene_start_time(ffmpeg_bin,recording_file,scene_number)
     ffmpeg_scene_command=ffmpeg_bin + " -i " + recording_file.shellescape + " -filter:v \"select='gt(scene,0.3)',showinfo\"  -frames:v " + scene_number.to_s + " -f null  - 2>&1|grep pts_time|sed 's/.*pts_time:\\([0-9.]*\\).*/\\1/'"
+
     @logger.info('Scene command is: ' + ffmpeg_scene_command)
     first_scene, stdeerr, status = Open3.capture3(ffmpeg_scene_command)
     # because of our sed here, status.success? will always be true so need to insepct the value further.
@@ -196,11 +195,13 @@ class Vconn1 < Test::Unit::TestCase
       @logger.error('ffmpeg scene detection command came back with unexpected output: ' + first_scene + ' :(')
       return false
     end
+
+    @logger.info('First scene detected as: ' + first_scene.to_s)
     return first_scene
   end
 
-  def ffmpeg_trim_video(ffmpeg_bin, recording_file, start_time, duration, output_file)
-    ffmpeg_trim_command=ffmpeg_bin + " -i " + recording_file.shellescape + " -ss " + start_time.to_s + " -t " + duration.to_s + " -c copy -strict -2 -an -y " + output_file.shellescape	
+  def ffmpeg_trim_video(ffmpeg_bin, recording_file, start_time, output_file)
+    ffmpeg_trim_command = ffmpeg_bin + " -i " + recording_file.shellescape + " -ss " + start_time.to_s +  " -c copy -y " + output_file.shellescape	
     @logger.info('Trim command is: ' + ffmpeg_trim_command)
     system ffmpeg_trim_command
     if $?.exitstatus != 0

--- a/ac_new.rb
+++ b/ac_new.rb
@@ -119,8 +119,8 @@ class Vconn1 < Test::Unit::TestCase
       @driver.find_element(:id, 'login-button').click
     end
     @driver.get(@base_url + '/' + meeting_id + '?launcher=false&fcsContent=true&pbMode=normal')
-		# this PID file is created by capture_audio.sh
-		steam_pid = out_dir + '/steam_' + meeting_id + '.pid' 
+	# this PID file is created by capture_audio.sh
+	steam_pid = out_dir + '/steam_' + meeting_id + '.pid' 
     # FFmpeg magic
     # record X11's display
     if !ffmpeg_x11_grab(ffmpeg_bin, meeting_id, resolution, frame_rate, x_display, extra_duration.to_s, recording_file, steam_pid)
@@ -152,19 +152,19 @@ class Vconn1 < Test::Unit::TestCase
   end
 
   def ffmpeg_x11_grab(ffmpeg_bin, meeting_id, resolution, frame_rate, x_display, duration, recording_file, steam_pid)
-		my_sink = nil
-		# wait for the capture_audio magic to end so that we'll have pulse audio sinks
-		while ! File.exist?(steam_pid)
-			sleep 5 
-		end
-		my_sink, stdeerr, status = Open3.capture3("pacmd list-sources | grep -PB 1 \"" + meeting_id + ".*monitor>\" |  head -n 1 | perl -pe 's/.* //g'")
-		my_sink = my_sink.delete!("\n")
-		my_sink = my_sink.to_i
-		if ! my_sink.is_a? Numeric
-			return false
-		end
-    
-		# override duration for faster testing/debugging 
+	my_sink = nil
+	# wait for the capture_audio magic to end so that we'll have pulse audio sinks
+	while ! File.exist?(steam_pid)
+		sleep 5 
+	end
+	my_sink, stdeerr, status = Open3.capture3("pacmd list-sources | grep -PB 1 \"" + meeting_id + ".*monitor>\" |  head -n 1 | perl -pe 's/.* //g'")
+	my_sink = my_sink.delete!("\n")
+	my_sink = my_sink.to_i
+	if ! my_sink.is_a? Numeric
+		return false
+	end
+
+	# override duration for faster testing/debugging 
     # duration = 120
     ffmpeg_x11grab_command = ffmpeg_bin + ' -s ' + resolution + ' -framerate ' + frame_rate.to_s + ' -f x11grab -i :' + x_display.to_s + ' -f pulse -i ' + my_sink.to_s + '  -c:v libx264  -acodec libmp3lame -crf 0 -preset ultrafast -t ' + duration.to_s + ' -vf "crop=in_w:in_h-147" -y ' + recording_file.shellescape
     @logger.info('X11grab command is: ' + ffmpeg_x11grab_command)

--- a/ac_setup_debian_ubuntu.sh
+++ b/ac_setup_debian_ubuntu.sh
@@ -21,22 +21,23 @@ else
     AC_BASE_PREFIX=/opt
 fi
 
-GECKODRIVER_VER=v0.21.0
+GECKODRIVER_VER=v0.24.0
 apt update
 apt install -y lsb-release software-properties-common
 DISTRO=`lsb_release -s -i`
 CODENAME=`lsb_release -c -s`
 if [ "$DISTRO" = 'Ubuntu' ]; then
     add-apt-repository "deb http://archive.canonical.com/ubuntu $CODENAME partner"
+    add-apt-repository ppa:jonathonf/ffmpeg-4
 fi
 apt update
-apt install -y sysvinit-utils curl unzip firefox adobe-flashplugin ffmpeg ruby ruby-dev libffi-dev xvfb zlib1g-dev libxml2-dev dos2unix build-essential patch wget
+apt install -y sysvinit-utils curl unzip firefox adobe-flashplugin ffmpeg ruby ruby-dev libffi-dev xvfb zlib1g-dev libxml2-dev dos2unix build-essential patch wget vorbis-tools pulseaudio-utils pulseaudio
 gem install adobe_connect selenium-webdriver kaltura-client test-unit logger
 wget https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VER/geckodriver-$GECKODRIVER_VER-linux64.tar.gz -O /tmp/geckodriver-$GECKODRIVER_VER-linux64.tar.gz
 tar zxvf /tmp/geckodriver-${GECKODRIVER_VER}-linux64.tar.gz -C /usr/local/bin
 wget https://github.com/kaltura/adobe-connect-to-mkv-to-kaltura/archive/master.zip -O /tmp/adobe-connect-to-mkv-to-kaltura.zip
 unzip -qoo /tmp/adobe-connect-to-mkv-to-kaltura.zip -d /tmp
-mv /tmp/adobe-connect-to-mkv-to-kaltura-master $AC_BASE_PREFIX
+mv /tmp/adobe-connect-to-mkv-to-kaltura-master $AC_BASE_PREFIX/adobe-connect-to-mkv-to-kaltura
 
 # or, if you prefer to clone, comment the 2 lines above and uncomment these:
 #cd $AC_BASE_PREFIX
@@ -44,3 +45,7 @@ mv /tmp/adobe-connect-to-mkv-to-kaltura-master $AC_BASE_PREFIX
 cd $AC_BASE_PREFIX/adobe-connect-to-mkv-to-kaltura
 cp xvfb-run-safe /usr/local/bin
 cp ac.rc /etc/profile.d/ac.sh
+# run the pulseaudio daemon on DISPLAY 1 [never used by ac_wrapper as it starts assigning displayed from 99 and above]
+# pulseaudio will be used for recording the audio streams using ffmpeg x11grab in ac_new.rb
+Xvfb :1 -screen 0 1280x720x24 &
+DISPLAY=:1 pulseaudio --start --disallow-exit -vvv --log-target=newfile:"/var/tmp/mypulseaudio.log"

--- a/capture_audio.sh
+++ b/capture_audio.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+if [ $# -lt 1 ]; then
+    echo "Usage $0 <recording ID>"
+    exit 1
+fi
+REC_ID=$1
+if [ -z "$OUTDIR" ]; then
+    OUTDIR=/tmp/ac_output
+fi
+rm -f $OUTDIR/steam_${REC_ID}.ogg $OUTDIR/steam_${REC_ID}.pid  
+OLD_SINK_ID=`pactl list short modules|grep "sink_name=steam_${REC_ID}"|awk -F " " '{print $1}'|xargs` 
+if [ -n "$OLD_SINK_ID" ];then
+	pactl unload-module $OLD_SINK_ID
+fi
+
+LAST_INDEX=`pacmd list-sink-inputs|grep "^\s*index:"|awk -F ": " '{print $2}' |tail -1`
+SINK_ID=`pactl load-module module-null-sink sink_name=steam_${REC_ID}`
+echo $SINK_ID
+pactl move-sink-input $LAST_INDEX steam_${REC_ID}
+# uncomment one of these if you wish to debug the audio while Firefox is running
+#nohup sh -c "parec -d steam_${REC_ID}.monitor | oggenc -b 192 -o $OUTDIR/steam_${REC_ID}.ogg --raw -" &
+#nohup sh -c "parec -d steam_${REC_ID}.monitor | sox -t raw -b 16 -e signed -c 2 -r 44100 - $OUTDIR/steam_${REC_ID}.wav" &
+echo $! > $OUTDIR/steam_${REC_ID}.pid

--- a/xvfb-run-safe
+++ b/xvfb-run-safe
@@ -24,6 +24,7 @@ while ((i < XVFB_DISPLAY_MAX)); do
     exec 5> "$XVFB_LOCKDIR/$i" || continue # open a lockfile
     if flock -x -n 5; then # attempt lock
         export X_SERVER_DISPLAY_NUM=$i               # export selected display for use in subsequent scripts
+	echo $X_SERVER_DISPLAY_NUM > /var/tmp/last_xvfb_display
         exec xvfb-run --server-num="$i" "$@" || exit # once locked, run xvfb-run on selected display
     fi
     ((i++))


### PR DESCRIPTION
This allows for a far better sync between audio and video tracks and also faster processing [since we no longer need to merge the audio track downloaded in get_ac_audio.sh and therefore also don't need the scene detection proc]
`get_ac_audio.sh` is still called in order to determine the session's duration however, since we need to know how long we need to record for [this value, plus a buffer, is then passed to the ffmpeg x11grab command, strictly speaking, the buffer should no longer be needed but I left it there for now].
This approach also means that trimming the entry is no longer necessary because we only start recording when Firefox registers an audio source, which only happens after playback commences. 