### PR TITLE
FIx for files > 5GB

### DIFF
--- a/ac_new.rb
+++ b/ac_new.rb
@@ -337,8 +337,8 @@ class Vconn1 < Test::Unit::TestCase
                 	final_chunk = true
         	end
 		begin
-        		results = client.upload_token_service.upload(upload_token_id, File.open(File.join(chunked_dir,'piece0' + i.to_s)), resume, final_chunk, resume_at)
-        		resume_at += File.size(File.join(chunked_dir,'piece0' + i.to_s))
+        		results = client.upload_token_service.upload(upload_token_id, File.open(File.join(chunked_dir,'piece' + format('%02d', i.to_s))), resume, final_chunk, resume_at)
+        		resume_at += File.size(File.join(chunked_dir,'piece' + format('%02d', i.to_s)))
         		i += 1
 		rescue Kaltura::KalturaAPIError => e
 			@logger.error("Exception Class: #{e.class.name}")


### PR DESCRIPTION
Files greater than 5GB produce a split result of more than 10 files, causing the script to search for "piece010" and fail.